### PR TITLE
Have AMD main module creation handle a main of "." when they mean "index.js"

### DIFF
--- a/vololib/amdify.js
+++ b/vololib/amdify.js
@@ -136,6 +136,10 @@ define(function (require, exports, module) {
                                .replace(/^\.\//, '')
                                .replace(/\.js$/, ''),
                 contents;
+                //Some packages use a main of "." to mean "index.js" in this
+                //directory.
+                if (mainName === '.')
+                  mainName = "index";
 
                 //Add in adapter module for AMD code
                 contents = "define(['" + localName + "/" + mainName +


### PR DESCRIPTION
See:
https://github.com/andris9/mimelib/blob/master/package.json#L17

This was resulting in the auto-main file having an explicit dependency of "./mimelib/.", which is not super useful.  I had another module that had an index.js file present, but not mentioned in the package.json at all.  In that case you could check if there is an index.js that would be found by the default search logic, but it all depends on how accepting of not-great package.json files you want to be.
