### PR TITLE
Windows path fix in file.mkdirs

### DIFF
--- a/vololib/volo/file.js
+++ b/vololib/volo/file.js
@@ -86,6 +86,8 @@ define(function (require) {
          * @param {String} dir the directory to create.
          */
         mkdirs: function (dir) {
+            dir = frontSlash(dir)
+            
             var parts = dir.split('/'),
                 currDir = '',
                 first = true;


### PR DESCRIPTION
Volo can't deal with a path of multiple folders when trying to use `v.mkdir`. E.g. this will fail:

```
v.mkdir("my/dir")
```

This commit fixes it, and is essentially the same fix that @sammyt did in #23
