### PR TITLE
Make sure directory does not exist before making it

### DIFF
--- a/vololib/volo/unzip.js
+++ b/vololib/volo/unzip.js
@@ -31,7 +31,9 @@ define(function (require) {
                 }
 
                 if (entry.isDirectory()) {
-                    fs.mkdirSync(name);
+                    if (!path.existsSync(name)) {
+                        fs.mkdirSync(name);
+                    }
                 } else {
                     dirName = path.dirname(name);
                     if (!path.existsSync(dirName)) {


### PR DESCRIPTION
In unzip module, I added a condition to test if the directory exist before creating it. I had an issue while unzipping a compressed initializr package. 

Thanks!
