### PR TITLE
Typo in documentation for add-command.

### DIFF
--- a/commands/add/doc.md
+++ b/commands/add/doc.md
@@ -72,7 +72,7 @@ by **amdify** can als be used with **add**.
 Here is a command that fetches Backbone and wraps in it in an AMD define() call,
 specifying 'jquery' and 'underscore' as dependencies:
 
-    volo add -amd documentcloud/backbone depend=underscore,jquery exports=Backbone
+    volo add -amd documentcloud/backbone depends=underscore,jquery exports=Backbone
 
 
 ## Installation Details


### PR DESCRIPTION
The documentation for 'add' specifies an optional 'depend' argument, which should be called 'depends'.
