### PR TITLE
Fixes #119, bump package.json's engines.node version to be 0.8 or higher...

### DIFF
--- a/commands/add/doc.md
+++ b/commands/add/doc.md
@@ -67,7 +67,7 @@ through the module ID:
 
 When the -amd flag is used, the the **amdify** command is used to convert
 the file downloaded by the **add** command, so the named arguments supported
-by **amdify** can als be used with **add**.
+by **amdify** can also be used with **add**.
 
 Here is a command that fetches Backbone and wraps in it in an AMD define() call,
 specifying 'jquery' and 'underscore' as dependencies:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     },
 
     "engines": {
-        "node": ">=0.6.7"
+        "node": ">=0.8"
     },
 
     "dependencies": {


### PR DESCRIPTION
I'm not 100% that I really had the volo test environment correct, but I did do the suggested `npm link; cd tests; ./all.js` incantation and it said all tests passed.

I can verify that node v0.8.15 correctly terminates commands.  Fixed a small typo since I was there.
