### PR TITLE
Add nodejs v6 support to add command

### DIFF
--- a/commands/add.js
+++ b/commands/add.js
@@ -34,7 +34,7 @@ var fs = require('fs'),
 
 function getUnzippedDirInfo(tempDirName, fullZipPath) {
     var baseDir,
-        zipName = path.basename(fullZipPath),
+        zipName = fullZipPath == null ? null : path.basename(fullZipPath),
         determinedBase = false;
 
     fs.readdirSync(tempDirName).some(function (entry) {


### PR DESCRIPTION
path.basename throws an error in version 6 of node if the path argument is not a string. In my case the value was undefined. I found this error while attempting `volo add requirejs/text`.