### PR TITLE
docs: Fix simple typo, withint -> within

### DIFF
--- a/lib/archive.js
+++ b/lib/archive.js
@@ -50,7 +50,7 @@ module.exports = (archiveLib = {
      * * url: the http/https URL to fetch the archive or single file
      * * isArchive: true if the URL points to a .tar.gz file.
      * * fragment: if a fragment ID (# part) was specified on the original
-     *             archive value, normally meaning a file withint an archive
+     *             archive value, normally meaning a file within an archive
      * * localName: a possible local name to use for the extracted archive
      *              value. Useful to use when an explicit one is not
      *              specified by the user.

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -404,7 +404,7 @@ parse.findAnonDefineFactory = function (node) {
  */
 parse.findConfig = function (fileName, fileContents) {
     /*jslint evil: true */
-    //This is a litle bit inefficient, it ends up with two uglifyjs parser
+    //This is a little bit inefficient, it ends up with two uglifyjs parser
     //calls. Can revisit later, but trying to build out larger functional
     //pieces first.
     var foundConfig = null,
@@ -434,7 +434,7 @@ parse.findConfig = function (fileName, fileContents) {
  * have not been normalized, they may be relative IDs.
  */
 parse.findDependencies = function (fileName, fileContents, options) {
-    //This is a litle bit inefficient, it ends up with two uglifyjs parser
+    //This is a little bit inefficient, it ends up with two uglifyjs parser
     //calls. Can revisit later, but trying to build out larger functional
     //pieces first.
     var dependencies = [],
@@ -459,7 +459,7 @@ parse.findDependencies = function (fileName, fileContents, options) {
  * Finds only CJS dependencies, ones that are the form require('stringLiteral')
  */
 parse.findCjsDependencies = function (fileName, fileContents, options) {
-    //This is a litle bit inefficient, it ends up with two uglifyjs parser
+    //This is a little bit inefficient, it ends up with two uglifyjs parser
     //calls. Can revisit later, but trying to build out larger functional
     //pieces first.
     var dependencies = [],


### PR DESCRIPTION
There is a small typo in lib/archive.js.

Should read `within` rather than `withint`.

