### PR TITLE
docs: Fix a few typos

### DIFF
--- a/tests/commands/create/support/addOnCreate/js/jquery.js
+++ b/tests/commands/create/support/addOnCreate/js/jquery.js
@@ -3720,7 +3720,7 @@ var cachedruns,
 
 	rcombinators = new RegExp( "^" + combinators ),
 
-	// All simple (non-comma) selectors, excluding insignifant trailing whitespace
+	// All simple (non-comma) selectors, excluding insignificant trailing whitespace
 	rgroups = new RegExp( groups + "?(?=" + whitespace + "*,|$)", "g" ),
 
 	// A selector, or everything after leading whitespace

--- a/tests/doh/_browserRunner.js
+++ b/tests/doh/_browserRunner.js
@@ -677,7 +677,7 @@ if(window["dojo"]){
 			loaded = true;
 			groupTemplate = byId("groupTemplate");
 			if(!groupTemplate){
-				// make sure we've got an ammenable DOM structure
+				// make sure we've got an amenable DOM structure
 				return;
 			}
 			groupTemplate.parentNode.removeChild(groupTemplate);


### PR DESCRIPTION
There are small typos in:
- tests/commands/create/support/addOnCreate/js/jquery.js
- tests/doh/_browserRunner.js

Fixes:
- Should read `insignificant` rather than `insignifant`.
- Should read `amenable` rather than `ammenable`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md